### PR TITLE
Fix/adjusting data transfer speed

### DIFF
--- a/converter/dataSenderGenerator.go
+++ b/converter/dataSenderGenerator.go
@@ -27,7 +27,7 @@ func NewDataSenderGenerator(bufferSize int) *DataSenderGenerator {
 		panic("data sender was created but no websocket configuration was provided. Please refer to the user manual")
 	}
 
-	writeAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 2918} // we don't need to care about this address
+	writeAddr := &net.UDPAddr{IP: net.ParseIP("0.0.0.0"), Port: 2918} // we don't need to care about this address
 	readAddr := &net.UDPAddr{IP: net.ParseIP(config.WebSocketConfig.Ip), Port: config.WebSocketConfig.Port}
 
 	conn, err := net.DialUDP("udp", writeAddr, readAddr)
@@ -53,7 +53,8 @@ func (dsg *DataSenderGenerator) GenerateSignal() {
 	go randomGenerator.GenerateSignal()
 	log.Printf("Starting data sender with the following config: %v \n", config.WebSocketConfig)
 
-	ticker := time.NewTicker(200 * time.Millisecond)
+	// 32 bits every 800 ms is (approximately) 1 character every 200 ms
+	ticker := time.NewTicker(800 * time.Millisecond)
 	defer ticker.Stop()
 	for range ticker.C {
 		// Read packages of 4 Bytes from the channel

--- a/interpreter/binaryDataBypassReader.go
+++ b/interpreter/binaryDataBypassReader.go
@@ -22,7 +22,7 @@ func (reader *BinaryDataBypassReader) GetChannel() <-chan models.Binary {
 }
 
 func (reader *BinaryDataBypassReader) ReadChannel() {
-	ticker := time.NewTicker(200 * time.Millisecond)
+	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
 	for range ticker.C {

--- a/runConfigurations/dataReceiver.json
+++ b/runConfigurations/dataReceiver.json
@@ -3,7 +3,7 @@
     "generatorType": "dataReceiver",
     "validationBypass": true,
     "WebSocketConfig": {
-        "ip": "127.0.0.1",
+        "ip": "0.0.0.0",
         "port": 8080
     }
 }

--- a/runConfigurations/dataSender.json
+++ b/runConfigurations/dataSender.json
@@ -3,7 +3,7 @@
     "generatorType": "dataSender",
     "validationBypass": true,
     "WebSocketConfig": {
-        "ip": "127.0.0.1",
+        "ip": "0.0.0.0",
         "port": 8080
     }
 }


### PR DESCRIPTION
In recent experiments we've identified that the speed of text transfer between data sender and receiver was too high. Making difficult for some data to be identified manually. This PR fixes that.