### PR TITLE
Feat/adding possibility to filter during calibration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,8 +5,7 @@
         "type": "go",
         "request": "launch",
         "mode": "auto",
-        "program": "${workspaceFolder}",
-        "args": ["-config", "./runConfigurations/calibration.json"]
+        "program": "${workspaceFolder}"
     }
     ]
     

--- a/interpreter/calibratorReader.go
+++ b/interpreter/calibratorReader.go
@@ -36,8 +36,9 @@ func (calibrator *Calibrator) ReadChannel() {
 			fmt.Println("error while reading binary data form channel: " + err.Error())
 		}
 
-		// filteredData := helpers.FilterUnderadableCharacters(textCharacter)
-
+		if config.ScreenExhibitionConfig.FilterUnderadable {
+			textCharacter = helpers.FilterUnderadableCharacters(textCharacter)
+		}
 		if textCharacter != "" {
 			for _, char := range textCharacter {
 				calibrator.CalibrationChannel <- string(char)

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 	validationBypass = executionConfig.ValidationBypass
 	config.WebSocketConfig = &executionConfig.WebSocketConfig
 	config.ScreenExhibitionConfig = &executionConfig.ScreenExhibitionConfig
-	config.CalibrationConfig = &executionConfig.CalibrationConfig
+	config.CalibrationConfig = executionConfig.CalibrationConfig
 
 	var signalGenerator converter.SignalGenerator
 	var channelInterpreter interpreter.ChannelInterpreter

--- a/models/executionConfig.go
+++ b/models/executionConfig.go
@@ -17,7 +17,7 @@ type ExecutionConfig struct {
 	ValidationBypass       bool                                `json:"validationBypass"`
 	WebSocketConfig        customTypes.WebsocketConnectionInfo `json:"webSocketConfig"`
 	ScreenExhibitionConfig customTypes.ScreenExhibitionConfig  `json:"screenExhibitionConfig"`
-	CalibrationConfig      customTypes.CalibrationConfig       `json:"calibrationConfig"`
+	CalibrationConfig      *customTypes.CalibrationConfig      `json:"calibrationConfig,omitempty"`
 }
 
 func (e *ExecutionConfig) ParseLanguage() customTypes.Language {


### PR DESCRIPTION
A minor bug discovered that always made Religare run in the calibration mode when it  runs with configurations that don't define a calibration