### PR TITLE
Adding statistics for constant receiver

### DIFF
--- a/converter/dataReceiverGenerator.go
+++ b/converter/dataReceiverGenerator.go
@@ -43,8 +43,14 @@ func NewDataReceiverGenerator(bufferSize int) *DataReceiverGenerator {
 }
 
 func (drg *DataReceiverGenerator) GenerateSignal() {
+
+	receiveQuantity := 4 * models.ByteSize
+	if config.ScreenExhibitionConfig.ConstantReceiver {
+		receiveQuantity = 1
+	}
+
 	// Read the first 32 bits of data from the connection
-	readBuffer := make([]byte, 4*models.ByteSize)
+	readBuffer := make([]byte, receiveQuantity)
 
 	log.Printf("Starting data receiver with the following config: %v \n", config.WebSocketConfig)
 	for {

--- a/converter/dataSenderGenerator.go
+++ b/converter/dataSenderGenerator.go
@@ -50,12 +50,16 @@ func (dsg *DataSenderGenerator) GenerateSignal() {
 	go dsg.internalGenerator.GenerateSignal()
 	log.Printf("Starting data sender with the following config: %v \n", config.WebSocketConfig)
 
-	// 32 bits every 100 ms
+	// Send data every 100 ms
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for range ticker.C {
+		bytesQuantity := 4
+		if _, ok := dsg.internalGenerator.(*ConstantSignalGenerator); ok {
+			bytesQuantity = 1
+		}
 		// Read packages of 4 Bytes from the channel
-		bytesToSend := readBytes(dsg.channel, 4)
+		bytesToSend := readBytes(dsg.channel, bytesQuantity)
 		// Send data to the websocket connection
 		_, err := dsg.connection.Write(bytesToSend)
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module religare
 
 go 1.22
 
-require github.com/google/uuid v1.6.0 // indirect
+require github.com/google/uuid v1.6.0

--- a/interpreter/binaryDataBypassReader.go
+++ b/interpreter/binaryDataBypassReader.go
@@ -52,7 +52,11 @@ func (reader *BinaryDataBypassReader) ReadChannel() {
 	}(sigs, config.ScreenExhibitionConfig)
 
 	for range ticker.C {
-		binaryCharacter := helpers.GetDataFromBinaryChannel(reader.Channel, 4*models.ByteSize)
+		bytesQuantity := 4 * models.ByteSize
+		if config.ScreenExhibitionConfig.ConstantReceiver {
+			bytesQuantity = 1
+		}
+		binaryCharacter := helpers.GetDataFromBinaryChannel(reader.Channel, bytesQuantity)
 
 		if config.ScreenExhibitionConfig.ConstantReceiver {
 			checkForZeros(binaryCharacter, &statistics)


### PR DESCRIPTION
We want to allow better statistics for the "constant receiver" mode. Also, this PR makes possible sending only one character at a time through the constant connection